### PR TITLE
III-3528 capture user info and env

### DIFF
--- a/app/ApiErrorHandler.php
+++ b/app/ApiErrorHandler.php
@@ -18,7 +18,7 @@ class ApiErrorHandler
         $this->uncaughtErrorHandler = $uncaughtErrorHandler;
     }
 
-    public function __invoke(Exception $exception): ApiProblemJsonResponse
+    public function handle(Exception $exception): ApiProblemJsonResponse
     {
         $this->uncaughtErrorHandler->handle($exception);
 

--- a/app/ApiErrorHandler.php
+++ b/app/ApiErrorHandler.php
@@ -9,11 +9,11 @@ use Exception;
 class ApiErrorHandler
 {
     /**
-     * @var UncaughtErrorHandler
+     * @var SentryErrorHandler
      */
     private $uncaughtErrorHandler;
 
-    public function __construct(UncaughtErrorHandler $uncaughtErrorHandler)
+    public function __construct(SentryErrorHandler $uncaughtErrorHandler)
     {
         $this->uncaughtErrorHandler = $uncaughtErrorHandler;
     }

--- a/app/ErrorHandlerProvider.php
+++ b/app/ErrorHandlerProvider.php
@@ -15,7 +15,8 @@ class ErrorHandlerProvider implements ServiceProviderInterface
             function ($app) {
                 return new SentryErrorHandler(
                     $app[HubInterface::class],
-                    $app['jwt'] ?? null
+                    $app['jwt'] ?? null,
+                    $app['auth.api_key'] ?? null
                 );
             }
         );

--- a/app/ErrorHandlerProvider.php
+++ b/app/ErrorHandlerProvider.php
@@ -8,7 +8,7 @@ use Silex\ServiceProviderInterface;
 
 class ErrorHandlerProvider implements ServiceProviderInterface
 {
-    public function register(Application $app)
+    public function register(Application $app): void
     {
         $app[UncaughtErrorHandler::class] = $app->share(
             function ($app) {
@@ -24,7 +24,7 @@ class ErrorHandlerProvider implements ServiceProviderInterface
         $app->error($app[ApiErrorHandler::class]);
     }
 
-    public function boot(Application $app)
+    public function boot(Application $app): void
     {
     }
 }

--- a/app/ErrorHandlerProvider.php
+++ b/app/ErrorHandlerProvider.php
@@ -10,15 +10,15 @@ class ErrorHandlerProvider implements ServiceProviderInterface
 {
     public function register(Application $app): void
     {
-        $app[UncaughtErrorHandler::class] = $app->share(
+        $app[SentryErrorHandler::class] = $app->share(
             function ($app) {
-                return new UncaughtErrorHandler($app[HubInterface::class]);
+                return new SentryErrorHandler($app[HubInterface::class]);
             }
         );
 
         $app[ApiErrorHandler::class] = $app->share(
             function () use ($app) {
-                return new ApiErrorHandler($app[UncaughtErrorHandler::class]);
+                return new ApiErrorHandler($app[SentryErrorHandler::class]);
             }
         );
         $app->error($app[ApiErrorHandler::class]);

--- a/app/ErrorHandlerProvider.php
+++ b/app/ErrorHandlerProvider.php
@@ -16,7 +16,8 @@ class ErrorHandlerProvider implements ServiceProviderInterface
                 return new SentryErrorHandler(
                     $app[HubInterface::class],
                     $app['jwt'] ?? null,
-                    $app['auth.api_key'] ?? null
+                    $app['auth.api_key'] ?? null,
+                    false
                 );
             }
         );

--- a/app/SentryErrorHandler.php
+++ b/app/SentryErrorHandler.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace CultuurNet\UDB3\UiTPASService;
 
+use CultuurNet\UDB3\ApiGuard\ApiKey\ApiKey;
 use CultuurNet\UDB3\Jwt\Udb3Token;
 use Sentry\State\HubInterface;
 use Sentry\State\Scope;
@@ -17,10 +18,14 @@ class SentryErrorHandler
     /** @var Udb3Token|null */
     private $udb3Token;
 
-    public function __construct(HubInterface $sentryHub, ?Udb3Token $udb3Token)
+    /** @var ApiKey|null */
+    private $apiKey;
+
+    public function __construct(HubInterface $sentryHub, ?Udb3Token $udb3Token, ?ApiKey $apiKey)
     {
         $this->sentryHub = $sentryHub;
         $this->udb3Token = $udb3Token;
+        $this->apiKey = $apiKey;
     }
 
     public function handle(Throwable $throwable): void
@@ -31,6 +36,7 @@ class SentryErrorHandler
 
         $this->sentryHub->configureScope(function (Scope $scope) {
             $scope->setUser($this->createUser($this->udb3Token));
+            $scope->setTags($this->createTags($this->apiKey));
         });
 
         $this->sentryHub->captureException($throwable);
@@ -47,6 +53,13 @@ class SentryErrorHandler
             'uid' => $udb3Token->jwtToken()->getClaim('uid', 'null'),
             'uitidv1id' => $udb3Token->jwtToken()->getClaim('https://publiq.be/uitidv1id', 'null'),
             'sub' => $udb3Token->jwtToken()->getClaim('sub', 'null'),
+        ];
+    }
+
+    private function createTags(?ApiKey $apiKey): array
+    {
+        return [
+            'api_key' => $apiKey ? $apiKey->toNative() : 'null',
         ];
     }
 }

--- a/app/SentryErrorHandler.php
+++ b/app/SentryErrorHandler.php
@@ -4,7 +4,9 @@ declare(strict_types=1);
 
 namespace CultuurNet\UDB3\UiTPASService;
 
+use CultuurNet\UDB3\Jwt\Udb3Token;
 use Sentry\State\HubInterface;
+use Sentry\State\Scope;
 use Throwable;
 
 class SentryErrorHandler
@@ -12,15 +14,39 @@ class SentryErrorHandler
     /** @var HubInterface */
     private $sentryHub;
 
-    public function __construct(HubInterface $sentryHub)
+    /** @var Udb3Token|null */
+    private $udb3Token;
+
+    public function __construct(HubInterface $sentryHub, ?Udb3Token $udb3Token)
     {
         $this->sentryHub = $sentryHub;
+        $this->udb3Token = $udb3Token;
     }
 
     public function handle(Throwable $throwable): void
     {
-        if ($throwable->getCode() !== 404) {
-            $this->sentryHub->captureException($throwable);
+        if ($throwable->getCode() === 404) {
+            return;
         }
+
+        $this->sentryHub->configureScope(function (Scope $scope) {
+            $scope->setUser($this->createUser($this->udb3Token));
+        });
+
+        $this->sentryHub->captureException($throwable);
+    }
+
+    private function createUser(?Udb3Token $udb3Token): array
+    {
+        if ($udb3Token === null) {
+            return ['id' => 'anonymous'];
+        }
+
+        return [
+            'id' => $udb3Token->id(),
+            'uid' => $udb3Token->jwtToken()->getClaim('uid', 'null'),
+            'uitidv1id' => $udb3Token->jwtToken()->getClaim('https://publiq.be/uitidv1id', 'null'),
+            'sub' => $udb3Token->jwtToken()->getClaim('sub', 'null'),
+        ];
     }
 }

--- a/app/SentryErrorHandler.php
+++ b/app/SentryErrorHandler.php
@@ -7,7 +7,7 @@ namespace CultuurNet\UDB3\UiTPASService;
 use Sentry\State\HubInterface;
 use Throwable;
 
-class UncaughtErrorHandler
+class SentryErrorHandler
 {
     /** @var HubInterface */
     private $sentryHub;

--- a/tests/ApiErrorHandlerTest.php
+++ b/tests/ApiErrorHandlerTest.php
@@ -12,7 +12,7 @@ class ApiErrorHandlerTest extends TestCase
     /** @var HubInterface|PHPUnit_Framework_MockObject_MockObject  */
     private $sentryHub;
 
-    /** @var UncaughtErrorHandler */
+    /** @var SentryErrorHandler */
     private $uncaughtErrorHandler;
 
     protected function setUp(): void
@@ -20,7 +20,7 @@ class ApiErrorHandlerTest extends TestCase
         parent::setUp();
 
         $this->sentryHub = $this->createMock(HubInterface::class);
-        $this->uncaughtErrorHandler = new UncaughtErrorHandler($this->sentryHub);
+        $this->uncaughtErrorHandler = new SentryErrorHandler($this->sentryHub);
     }
 
     /**

--- a/tests/ApiErrorHandlerTest.php
+++ b/tests/ApiErrorHandlerTest.php
@@ -20,7 +20,12 @@ class ApiErrorHandlerTest extends TestCase
         parent::setUp();
 
         $this->sentryHub = $this->createMock(HubInterface::class);
-        $this->uncaughtErrorHandler = new SentryErrorHandler($this->sentryHub);
+        $this->uncaughtErrorHandler = new SentryErrorHandler(
+            $this->sentryHub,
+            null,
+            null,
+            false
+        );
     }
 
     /**
@@ -34,7 +39,7 @@ class ApiErrorHandlerTest extends TestCase
         $this->sentryHub->expects($this->once())
             ->method('captureException');
 
-        $apiProblemResponse = $errorHandler->__invoke($exception);
+        $apiProblemResponse = $errorHandler->handle($exception);
 
         $this->assertEquals(
             '{"title":"Exception message","type":"about:blank","status":500}',
@@ -54,7 +59,7 @@ class ApiErrorHandlerTest extends TestCase
         $this->sentryHub->expects($this->once())
             ->method('captureException');
 
-        $apiProblemResponse = $errorHandler->__invoke($exception);
+        $apiProblemResponse = $errorHandler->handle($exception);
 
         $this->assertEquals(
             '{"title":"Exception message","type":"about:blank","status":400}',
@@ -74,7 +79,7 @@ class ApiErrorHandlerTest extends TestCase
         $this->sentryHub->expects($this->never())
             ->method('captureException');
 
-        $apiProblemResponse = $errorHandler->__invoke($exception);
+        $apiProblemResponse = $errorHandler->handle($exception);
 
         $this->assertEquals(
             '{"title":"Exception message","type":"about:blank","status":404}',
@@ -96,7 +101,7 @@ class ApiErrorHandlerTest extends TestCase
         $this->sentryHub->expects($this->once())
             ->method('captureException');
         
-        $apiProblemResponse = $errorHandler->__invoke($exception);
+        $apiProblemResponse = $errorHandler->handle($exception);
 
         $this->assertEquals(
             '{"title":"Exception message ","type":"about:blank","status":400}',

--- a/web/index.php
+++ b/web/index.php
@@ -10,7 +10,7 @@ use CultuurNet\UDB3\UiTPASService\Controller\EventControllerProvider;
 use CultuurNet\UDB3\UiTPASService\Controller\OrganizerControllerProvider;
 use CultuurNet\UDB3\UiTPASService\ErrorHandlerProvider;
 use CultuurNet\UDB3\UiTPASService\SentryServiceProvider;
-use CultuurNet\UDB3\UiTPASService\UncaughtErrorHandler;
+use CultuurNet\UDB3\UiTPASService\SentryErrorHandler;
 use Silex\Application;
 use Silex\Provider\SecurityServiceProvider;
 use Silex\Provider\ServiceControllerServiceProvider;
@@ -114,6 +114,6 @@ $app->after($app['cors']);
 try {
     $app->run();
 } catch (Throwable $throwable) {
-    $app[UncaughtErrorHandler::class]->handle($throwable);
+    $app[SentryErrorHandler::class]->handle($throwable);
     throw $throwable;
 }


### PR DESCRIPTION
### Added

- Capture user information (ID, sub, uid, uitidv1id)
- Capture runtime information (api_key, web/cli)

---

Ticket: https://jira.uitdatabank.be/browse/III-3528

Note: the unit test was not modified to verify the user information or tags because the format is driven by an external integration